### PR TITLE
feat: Add positions and trades commands for wallet data

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -477,10 +477,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "dotenv"
-version = "0.15.0"
+name = "dotenvy"
+version = "0.15.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "77c90badedccf4105eca100756a0b1289e191f6fcbdadd3cee1d2f614f97da8f"
+checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
 
 [[package]]
 name = "dyn-clone"
@@ -1286,7 +1286,7 @@ dependencies = [
  "chrono",
  "clap",
  "config",
- "dotenv",
+ "dotenvy",
  "fastrand",
  "futures",
  "mockito",
@@ -1294,6 +1294,7 @@ dependencies = [
  "rmcp",
  "serde",
  "serde_json",
+ "slab",
  "thiserror 1.0.69",
  "tokio",
  "tokio-test",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,7 +20,7 @@ serde_json = "1.0"
 
 # Configuration and utilities
 config = "0.14"
-dotenv = "0.15"
+dotenvy = "0.15"  # Replaces unmaintained dotenv (RUSTSEC-2021-0141)
 clap = { version = "4.0", features = ["derive"] }
 fastrand = "2.0"
 
@@ -32,7 +32,10 @@ uuid = { version = "1.0", features = ["v4"] }
 
 # Logging
 tracing = "0.1"
-tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+tracing-subscriber = { version = "0.3.20", features = ["env-filter"] }  # RUSTSEC-2025-0055 fix
+
+# Force updated transitive dependencies for security fixes
+slab = "0.4.11"  # RUSTSEC-2025-0047 fix
 
 [dev-dependencies]
 tokio-test = "0.4"

--- a/src/cli.rs
+++ b/src/cli.rs
@@ -97,6 +97,22 @@ pub enum Commands {
         #[arg(short, long)]
         args: Option<String>,
     },
+
+    /// Get positions for a wallet address
+    Positions {
+        /// Wallet address (0x...)
+        wallet: String,
+    },
+
+    /// Get trade history for a wallet address
+    Trades {
+        /// Wallet address (0x...)
+        wallet: String,
+
+        /// Maximum number of trades to return
+        #[arg(short, long, default_value = "50")]
+        limit: u32,
+    },
 }
 
 /// Format output based on the selected format

--- a/src/config.rs
+++ b/src/config.rs
@@ -26,6 +26,7 @@ pub struct ServerConfig {
 #[derive(Clone, Serialize, Deserialize)]
 pub struct ApiConfig {
     pub base_url: String,
+    pub clob_url: String,
     pub api_key: Option<String>,
     pub timeout_seconds: u64,
     pub max_retries: u32,
@@ -37,6 +38,7 @@ impl std::fmt::Debug for ApiConfig {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("ApiConfig")
             .field("base_url", &self.base_url)
+            .field("clob_url", &self.clob_url)
             .field("api_key", &self.api_key.as_ref().map(|_| "[REDACTED]"))
             .field("rate_limit_per_second", &self.rate_limit_per_second)
             .finish()
@@ -72,6 +74,7 @@ impl Default for Config {
             },
             api: ApiConfig {
                 base_url: "https://gamma-api.polymarket.com".to_string(),
+                clob_url: "https://data-api.polymarket.com".to_string(),
                 api_key: None,
                 timeout_seconds: 30,
                 max_retries: 3,
@@ -183,6 +186,9 @@ impl Config {
         // API configuration
         if let Ok(val) = env::var("POLYMARKET_API_BASE_URL") {
             config.api.base_url = val;
+        }
+        if let Ok(val) = env::var("POLYMARKET_CLOB_URL") {
+            config.api.clob_url = val;
         }
         if let Ok(val) = env::var("POLYMARKET_API_KEY") {
             config.api.api_key = Some(val);

--- a/src/main.rs
+++ b/src/main.rs
@@ -321,7 +321,7 @@ async fn main() -> Result<()> {
     let cli = Cli::parse();
 
     // Load environment variables from .env file if it exists
-    dotenv::dotenv().ok();
+    dotenvy::dotenv().ok();
 
     // Load configuration with optional config file override
     let mut config = Config::load()?;

--- a/src/main.rs
+++ b/src/main.rs
@@ -82,6 +82,24 @@ impl PolymarketMcpServer {
         }))
     }
 
+    pub async fn get_positions(&self, wallet: String) -> Result<Value> {
+        let positions = self.client.get_user_positions(&wallet).await?;
+        Ok(json!({
+            "wallet": wallet,
+            "positions": positions,
+            "count": positions.len()
+        }))
+    }
+
+    pub async fn get_trades(&self, wallet: String, limit: Option<u32>) -> Result<Value> {
+        let trades = self.client.get_user_trades(&wallet, limit).await?;
+        Ok(json!({
+            "wallet": wallet,
+            "trades": trades,
+            "count": trades.len()
+        }))
+    }
+
     // MCP Resources Support
     pub async fn list_resources(&self) -> Result<Value> {
         let resources = vec![
@@ -373,6 +391,12 @@ async fn main() -> Result<()> {
                 .transpose()
                 .map_err(|e| anyhow::anyhow!("Invalid JSON arguments: {e}"))?;
             execute_and_print(|| server.get_prompt(&name, arguments), cli.output).await
+        }
+        Some(Commands::Positions { wallet }) => {
+            execute_and_print(|| server.get_positions(wallet), cli.output).await
+        }
+        Some(Commands::Trades { wallet, limit }) => {
+            execute_and_print(|| server.get_trades(wallet, Some(limit)), cli.output).await
         }
     }
 }

--- a/src/models.rs
+++ b/src/models.rs
@@ -211,29 +211,44 @@ pub struct PositionsResponse {
     pub next_cursor: Option<String>,
 }
 
-/// Trade from the CLOB API
+/// Trade from the Polymarket Data API
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Trade {
     #[serde(default)]
     pub id: Option<String>,
-    #[serde(alias = "market", default)]
-    pub market_id: Option<String>,
-    #[serde(alias = "outcome", alias = "token_id", default)]
-    pub outcome_id: Option<String>,
+    #[serde(alias = "conditionId", default)]
+    pub condition_id: Option<String>,
+    #[serde(alias = "asset", default)]
+    pub asset: Option<String>,
+    #[serde(default)]
+    pub outcome: Option<String>,
+    #[serde(alias = "outcomeIndex", default)]
+    pub outcome_index: Option<u32>,
     #[serde(default)]
     pub side: Option<String>,
     #[serde(default)]
     pub size: Option<f64>,
     #[serde(default)]
     pub price: Option<f64>,
-    #[serde(alias = "time", alias = "created_at", default)]
-    pub timestamp: Option<String>,
-    #[serde(alias = "trader", alias = "user", default)]
-    pub trader_address: Option<String>,
-    #[serde(alias = "status", default)]
-    pub status: Option<String>,
-    #[serde(alias = "fee", default)]
-    pub fee: Option<f64>,
+    #[serde(
+        default,
+        deserialize_with = "deserialize_optional_timestamp"
+    )]
+    pub timestamp: Option<i64>,
+    #[serde(alias = "proxyWallet", default)]
+    pub proxy_wallet: Option<String>,
+    #[serde(default)]
+    pub title: Option<String>,
+    #[serde(default)]
+    pub slug: Option<String>,
+    #[serde(alias = "eventSlug", default)]
+    pub event_slug: Option<String>,
+    #[serde(alias = "transactionHash", default)]
+    pub transaction_hash: Option<String>,
+    #[serde(default)]
+    pub name: Option<String>,
+    #[serde(default)]
+    pub pseudonym: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -530,6 +545,19 @@ where
         Ok(Some(_)) => Err(serde::de::Error::custom("Expected string or number")),
         Ok(None) => Ok(None),
         Err(_) => Ok(None), // If field is missing, return None
+    }
+}
+
+/// Deserialize timestamp that can be either integer or string
+fn deserialize_optional_timestamp<'de, D>(deserializer: D) -> Result<Option<i64>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    use serde_json::Value;
+    match Option::<Value>::deserialize(deserializer) {
+        Ok(Some(Value::Number(n))) => Ok(n.as_i64()),
+        Ok(Some(Value::String(s))) => s.parse::<i64>().map(Some).map_err(serde::de::Error::custom),
+        _ => Ok(None),
     }
 }
 

--- a/src/models.rs
+++ b/src/models.rs
@@ -230,10 +230,7 @@ pub struct Trade {
     pub size: Option<f64>,
     #[serde(default)]
     pub price: Option<f64>,
-    #[serde(
-        default,
-        deserialize_with = "deserialize_optional_timestamp"
-    )]
+    #[serde(default, deserialize_with = "deserialize_optional_timestamp")]
     pub timestamp: Option<i64>,
     #[serde(alias = "proxyWallet", default)]
     pub proxy_wallet: Option<String>,

--- a/src/models.rs
+++ b/src/models.rs
@@ -511,9 +511,7 @@ where
                 .collect();
             Ok(Some(strings?))
         }
-        Ok(Some(Value::Null)) => Ok(None),
-        Ok(None) => Ok(None),
-        Err(_) => Ok(None), // If field is missing, return None
+        // Handles null, deserialization errors, and other unexpected JSON value types
         _ => Ok(None),
     }
 }

--- a/src/models.rs
+++ b/src/models.rs
@@ -178,16 +178,31 @@ pub struct EventResponse {
     pub next_cursor: Option<String>,
 }
 
+/// User position in a market from the CLOB API
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Position {
-    pub id: String,
-    pub market_id: String,
-    pub user_address: String,
-    pub outcome_id: String,
-    pub shares: f64,
-    pub value: f64,
-    pub cost_basis: f64,
-    pub unrealized_pnl: f64,
+    #[serde(default)]
+    pub id: Option<String>,
+    #[serde(alias = "market", default)]
+    pub market_id: Option<String>,
+    #[serde(alias = "user", default)]
+    pub user_address: Option<String>,
+    #[serde(alias = "outcome", alias = "token_id", default)]
+    pub outcome_id: Option<String>,
+    #[serde(alias = "size", default)]
+    pub shares: Option<f64>,
+    #[serde(default)]
+    pub value: Option<f64>,
+    #[serde(alias = "avgPrice", default)]
+    pub avg_price: Option<f64>,
+    #[serde(default)]
+    pub cost_basis: Option<f64>,
+    #[serde(alias = "pnl", default)]
+    pub unrealized_pnl: Option<f64>,
+    #[serde(alias = "asset", default)]
+    pub asset: Option<String>,
+    #[serde(alias = "side", default)]
+    pub side: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -196,16 +211,29 @@ pub struct PositionsResponse {
     pub next_cursor: Option<String>,
 }
 
+/// Trade from the CLOB API
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct Trade {
-    pub id: String,
-    pub market_id: String,
-    pub outcome_id: String,
-    pub side: String, // "buy" or "sell"
-    pub size: f64,
-    pub price: f64,
-    pub timestamp: String,
+    #[serde(default)]
+    pub id: Option<String>,
+    #[serde(alias = "market", default)]
+    pub market_id: Option<String>,
+    #[serde(alias = "outcome", alias = "token_id", default)]
+    pub outcome_id: Option<String>,
+    #[serde(default)]
+    pub side: Option<String>,
+    #[serde(default)]
+    pub size: Option<f64>,
+    #[serde(default)]
+    pub price: Option<f64>,
+    #[serde(alias = "time", alias = "created_at", default)]
+    pub timestamp: Option<String>,
+    #[serde(alias = "trader", alias = "user", default)]
     pub trader_address: Option<String>,
+    #[serde(alias = "status", default)]
+    pub status: Option<String>,
+    #[serde(alias = "fee", default)]
+    pub fee: Option<f64>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/polymarket_client.rs
+++ b/src/polymarket_client.rs
@@ -315,6 +315,47 @@ impl PolymarketClient {
 
         self.get_markets(Some(params)).await
     }
+
+    /// Gets positions for a specific wallet address.
+    ///
+    /// Uses the Polymarket Data API to fetch current positions.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    /// - The API request fails
+    /// - The response cannot be deserialized
+    pub async fn get_user_positions(&self, wallet_address: &str) -> Result<Vec<Position>> {
+        let url = format!(
+            "{}/positions?user={}",
+            self.config.api.clob_url, wallet_address
+        );
+        let response: Vec<Position> = self.make_request_with_retry(&url).await?;
+        Ok(response)
+    }
+
+    /// Gets trade history for a specific wallet address.
+    ///
+    /// Uses the Polymarket Data API to fetch trade history.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error if:
+    /// - The API request fails
+    /// - The response cannot be deserialized
+    pub async fn get_user_trades(
+        &self,
+        wallet_address: &str,
+        limit: Option<u32>,
+    ) -> Result<Vec<Trade>> {
+        let limit = limit.unwrap_or(50);
+        let url = format!(
+            "{}/trades?user={}&limit={}",
+            self.config.api.clob_url, wallet_address, limit
+        );
+        let response: Vec<Trade> = self.make_request_with_retry(&url).await?;
+        Ok(response)
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary
- Add `positions` command to fetch user positions from Polymarket Data API
- Add `trades` command to fetch user trade history
- Add `clob_url` config field for Data API endpoint
- Use flexible serde aliases to handle varying API response formats

## ⚠️ Dependencies
**This PR depends on #5** (CLI interface) and should be merged after it.

## Usage
```bash
# Get positions for a wallet
polymarket-mcp positions 0xdb27bf2ac5d428a9c63dbc914611036855a6c56e

# Get trade history (default 50 trades)
polymarket-mcp trades 0xdb27bf2ac5d428a9c63dbc914611036855a6c56e --limit 10
```

## Example Output
```bash
$ polymarket-mcp positions 0xdb27bf2ac5d428a9c63dbc914611036855a6c56e
{
  "count": 100,
  "positions": [
    {
      "outcome_id": "Nuggets",
      "shares": 709902.6954,
      "avg_price": 0.1495
    },
    ...
  ]
}

$ polymarket-mcp trades 0xdb27bf2ac5d428a9c63dbc914611036855a6c56e --limit 1
{
  "count": 1,
  "trades": [
    {
      "title": "Will AFC Bournemouth win on 2026-01-03?",
      "side": "BUY",
      "size": 122615.13,
      "price": 0.15,
      "outcome": "Yes",
      "timestamp": 1767459233
    }
  ]
}
```

## Test Addresses (from Polymarket Leaderboard)
- `0xdb27bf2ac5d428a9c63dbc914611036855a6c56e` - DrPufferfish (top trader)
- `0x37e4728b3c4607fb2b3b205386bb1d1fb1a8c991` - SemyonMarmeladov
- `0x6a72f61820b26b1fe4d956e17b6dc2a1ea3033ee` - kch123

## Test plan
- [x] Build succeeds: `cargo build --release`
- [x] All 9 tests passing
- [x] `positions` command tested with active trader
- [x] `trades` command tested with active trader
- [x] All 11 CLI commands verified working

🤖 Generated with [Claude Code](https://claude.com/claude-code)